### PR TITLE
v2: Simplify to only uploading the ADG to Spice Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 A composite GitHub Action that runs the Spice Labs CLI to create an artifact dependency
 graph from a directory of built files (e.g. Rust binaries, OCI-layout unpacked docker
-continers, jar files, etc), then uploads the resulting ADG to the Spice Labs servers
+continers, jar files, etc), then uploads the resulting ADG to the Spice Labs servers.
 
 ---
 
 ## Features
 
-- Scans a directory using `spicelabs/spice-labs-cli` container and creates an artifact dependency graph
+- Scans a directory using `spicelabs/spice-labs-cli` container and creates an artifact
+  dependency graph.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,35 @@
 # action-spice-labs-cli-scan
 
-A composite GitHub Action that runs the Spice Labs CLI scan against a directory of built files (e.g. Rust binaries), then uploads the resulting SBOM and OCI archive if present.
+A composite GitHub Action that runs the Spice Labs CLI to create an artifact dependency
+graph from a directory of built files (e.g. Rust binaries, OCI-layout unpacked docker
+continers, jar files, etc), then uploads the resulting ADG to the Spice Labs servers
 
 ---
 
 ## Features
 
-- Scans a directory using `spicelabs/spice-labs-cli:latest` Docker image
-- Exports SPDX SBOM (`/tmp/sbom.spdx.json`)
-- Uploads `.oci.tar` image files if present in scan target directory
-- Compatible with any containerized build output
+- Scans a directory using `spicelabs/spice-labs-cli` container and creates an artifact dependency graph
 
 ---
 
 ## Usage
 
 ```yaml
-- name: Run Spice Labs CLI Scan
-  uses: spice-labs-inc/action-spice-labs-cli-scan@main
+- name: Build ADG
+  uses: spice-labs-inc/action-spice-labs-cli-scan@v2
   with:
-    file_path: target/release/     # Optional, defaults to '.'
+    file_path: target/release/ # Optional, defaults to '.'
     spice_pass: ${{ secrets.SPICE_PASS }}
 ```
+
 ## Inputs
-| Name         | Required | Default | Description                                   |
-| ------------ | -------- | ------- | --------------------------------------------- |
-| `file_path`  | No       | `.`     | Path to local files to scan (read-only mount) |
-| `spice_pass` | Yes      | —       | Secret passphrase for running spice-labs-cli scan    |
 
-## Output
-This action uploads an artifact named spice-labs-cli-artifacts that may include:
-  *  `/tmp/sbom.spdx.json`
-  *  `*.oci.tar` files from the scan target path
-
-Set your downstream workflows to retrieve this as needed.
+| Name         | Required | Default | Description                                    |
+| ------------ | -------- | ------- | ---------------------------------------------- |
+| `file_path`  | No       | `.`     | Path to local files to scan (used read-only).  |
+| `spice_pass` | Yes      |         | Spice Pass (JWT) from your Spice Labs project. |
 
 ## Requirements
-  *  Docker must be available in the GitHub Actions runner
-  *  spicelabs/spice-labs-cli:latest image must be publicly accessible
+
+- Docker must be available in the GitHub Actions runner.
+- `spicelabs/spice-labs-cli` image must be publicly accessible.

--- a/action.yml
+++ b/action.yml
@@ -17,13 +17,13 @@ runs:
     - name: Run The Spice Labs CLI
       shell: bash
       run: |
-        set -euxo pipefail
-
         echo "🔍 Running The Spice Labs CLI Scan..."
+
         docker run \
           -v "${{ inputs.file_path }}:/input:ro" \
           -e SPICE_PASS="${{ inputs.spice_pass }}" \
           spicelabs/spice-labs-cli:latest \
+          --verbose \
           --input /input
 
         echo "✅ Scan complete"

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Run The Spice Labs CLI
+    - name: Build ADG
       shell: bash
       run: |
         echo "🔍 Running The Spice Labs CLI Scan..."
@@ -26,33 +26,4 @@ runs:
           --verbose \
           --input /input
 
-        echo "✅ Scan complete"
-
-    - name: Check for Generated Files
-      shell: bash
-      run: |
-        echo "📁 Checking if expected files exist..."
-        SBOM="/tmp/sbom.spdx.json"
-        ARTIFACTS=$(find "${{ inputs.file_path }}" -maxdepth 1 -name '*.oci.tar' 2>/dev/null || true)
-
-        if [[ -f "$SBOM" ]]; then
-          echo "✔ Found SBOM: $SBOM"
-        else
-          echo "⚠ No SBOM found at $SBOM"
-        fi
-
-        if [[ -n "$ARTIFACTS" ]]; then
-          echo "✔ Found OCI tar(s):"
-          echo "$ARTIFACTS"
-        else
-          echo "⚠ No .oci.tar files found in ${{ inputs.file_path }}"
-        fi
-
-    - name: Upload SBOM + OCI Tar (if present)
-      uses: actions/upload-artifact@v4
-      with:
-        name: spice-labs-cli-artifacts
-        path: |
-          /tmp/sbom.spdx.json
-          ${{ inputs.file_path }}/*.oci.tar
-        if-no-files-found: warn
+        echo "✅ ADG creation complete"

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Build ADG
       shell: bash
       run: |
-        echo "🔍 Running The Spice Labs CLI Scan..."
+        echo "🔍 Running The Spice Labs CLI Scan & Upload..."
 
         docker run \
           -v "${{ inputs.file_path }}:/input:ro" \
@@ -26,4 +26,4 @@ runs:
           --verbose \
           --input /input
 
-        echo "✅ ADG creation complete"
+        echo "✅ ADG creation & upload complete"

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,10 @@ runs:
         echo "🔍 Running The Spice Labs CLI Scan & Upload..."
 
         docker run \
-          -v "${{ inputs.file_path }}:/input:ro" \
+          -v "${{ inputs.file_path }}:/mnt/input:ro" \
           -e SPICE_PASS="${{ inputs.spice_pass }}" \
           spicelabs/spice-labs-cli:latest \
           --verbose \
-          --input /input
+          --input /mnt/input
 
         echo "✅ ADG creation & upload complete"


### PR DESCRIPTION
Since this is a composite action that can be used in the middle of other job steps, we can let other actions do image extraction, SBOM creation or extraction, and artifact upload, leaving this action a clean, single-purpose interface. 