### PR TITLE
Use version 0.2 release series

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
         docker run \
           -v "${{ inputs.file_path }}:/mnt/input:ro" \
           -e SPICE_PASS="${{ inputs.spice_pass }}" \
-          spicelabs/spice-labs-cli:latest \
+          spicelabs/spice-labs-cli:0.2 \
           --log-level all \
           --input /mnt/input \
           --tag "${{ inputs.tag }}"


### PR DESCRIPTION
Closes #7 

This means that this version of the action is intending to use the latest release of the CLI interface-compatible with v0.2 (v0.2.7 at the time of this writing); If we update the CLI without backward compatibility, it should be released under a new major (or 0.major since we're using the weird pre-1.0.0 semver numbering). This is just good practice anyway.

If we release a new, still-compatible version it should be 0.2.8, and picked up by this action. If it turns out not to be compatible, it should be rolled back or fixed as 0.2.9 (maintaining the interface compatibility and treating the breakage as a bug and bug fix)

